### PR TITLE
fix: ollama-deepseek-chat-client

### DIFF
--- a/spring-ai-alibaba-chat-example/ollama-deepseek-chat/ollama-deepseek-chat-client/src/main/java/com/alibaba/cloud/ai/example/chat/deepseek/controller/OllamaClientController.java
+++ b/spring-ai-alibaba-chat-example/ollama-deepseek-chat/ollama-deepseek-chat-client/src/main/java/com/alibaba/cloud/ai/example/chat/deepseek/controller/OllamaClientController.java
@@ -60,7 +60,7 @@ public class OllamaClientController {
 				// 设置 ChatClient 中 ChatModel 的 Options 参数
 				.defaultOptions(
 						OllamaOptions.builder()
-								.model("deepseek-r1")
+								.model("deepseek-r1:1.5b")
 								.topP(0.7)
 								.build()
 				)


### PR DESCRIPTION
需指定deepseek-r1的参数1.5b(与配置一致，不然会报RuntimeException：[404]Not Found -{"error":"model \"deepseek-r1\"not found,try pulling it first"}

![image](https://github.com/user-attachments/assets/4b995d94-92bd-487c-bc8d-93663b5778f9)

