### PR TITLE
build(starter-example): 更新 spring-ai-bom 依赖版本

### DIFF
--- a/spring-ai-alibaba-mcp-example/starter-example/pom.xml
+++ b/spring-ai-alibaba-mcp-example/starter-example/pom.xml
@@ -47,7 +47,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-bom</artifactId>
-				<version>1.0.0-SNAPSHOT</version>
+				<version>${spring-ai.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
- 将 spring-ai-bom依赖的版本从 1.0.0-SNAPSHOT 修改为 ${spring-ai.version}
- 此修改使得项目能够使用统一的 Spring AI 版本管理

