### PR TITLE
destroy()方法代码调整：防止误删FILE_PATH属性指向的用户本地重要目录

### DIFF
--- a/spring-ai-alibaba-audio-example/dashscope-audio/src/main/java/com/alibaba/cloud/ai/example/audio/tts/TTSController.java
+++ b/spring-ai-alibaba-audio-example/dashscope-audio/src/main/java/com/alibaba/cloud/ai/example/audio/tts/TTSController.java
@@ -115,8 +115,9 @@ public class TTSController implements ApplicationRunner {
 
 	@PreDestroy
 	public void destroy() throws IOException {
-
-		FileUtils.deleteDirectory(new File(FILE_PATH));
+		// 删除默认的示例路径
+		String example_file_path = "spring-ai-alibaba-audio-example/dashscope-audio/src/main/resources/gen/tts";
+		FileUtils.deleteDirectory(new File(example_file_path));
 	}
 
 }


### PR DESCRIPTION
destroy()方法代码调整：由于destroy()方法在类文件的最下边，此次代码调整增加了判断，防止用户没有看到下边这个destroy()方法，但是修改了FILE_PATH属性（如修改为本地Desktop或Download目录）而导致FILE_PATH被误删。
