### PR TITLE
application.yml配置文件中baidutranslate.app-id配置项名称多了个分号，现去掉

### DIFF
--- a/spring-ai-alibaba-tool-calling-example/src/main/resources/application.yml
+++ b/spring-ai-alibaba-tool-calling-example/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
       toolcalling:
         baidutranslate:
           enabled: true
-          app;-id: ${BAIDU_TRANSLATE_APP_ID}
+          app-id: ${BAIDU_TRANSLATE_APP_ID}
           secret-key: ${BAIDU_TRANSLATE_SECRET_KEY}
 
         time:


### PR DESCRIPTION
application.yml配置文件中baidutranslate.app-id配置项名称多了个分号，现去掉