### PR TITLE
新增功能：文件翻译示例

### DIFF
--- a/spring-ai-alibaba-translate-example/src/main/java/com/alibaba/example/translate/TranslateApplication.java
+++ b/spring-ai-alibaba-translate-example/src/main/java/com/alibaba/example/translate/TranslateApplication.java
@@ -52,6 +52,6 @@ public class TranslateApplication {
                 .withModel(DashScopeApi.ChatModel.QWEN_PLUS.getModel())
                 .build();
         
-        return new DashScopeChatModel(apiKey, options);
+        return new DashScopeChatModel(new DashScopeApi(apiKey), options);
     }
 }

--- a/spring-ai-alibaba-translate-example/src/main/java/com/alibaba/example/translate/controller/DashScopeTranslateController.java
+++ b/spring-ai-alibaba-translate-example/src/main/java/com/alibaba/example/translate/controller/DashScopeTranslateController.java
@@ -19,7 +19,10 @@ package com.alibaba.example.translate.controller;
 
 import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
 import com.alibaba.cloud.ai.dashscope.chat.DashScopeChatOptions;
+import com.alibaba.example.translate.controller.service.MarkdownTranslationService;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.multipart.MultipartFile;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.model.ChatModel;
@@ -31,6 +34,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.beans.factory.annotation.Qualifier;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 /**
  * DashScope翻译服务控制器
  * 提供基于DashScope大模型的文本翻译API
@@ -40,11 +48,14 @@ import org.springframework.beans.factory.annotation.Qualifier;
 public class DashScopeTranslateController {
 
 	private static final String TRANSLATION_PROMPT_TEMPLATE = "请将以下文本从%s翻译成%s：\n\n%s";
+	private final MarkdownTranslationService markdownTranslationService;
 
 	private final ChatModel dashScopeChatModel;
 
-	public DashScopeTranslateController(@Qualifier("dashScopeChatModel") ChatModel chatModel) {
+	public DashScopeTranslateController(@Qualifier("dashScopeChatModel") ChatModel chatModel,
+										MarkdownTranslationService markdownTranslationService) {
 		this.dashScopeChatModel = chatModel;
+		this.markdownTranslationService = markdownTranslationService;
 	}
 
 	/**
@@ -122,5 +133,37 @@ public class DashScopeTranslateController {
                 .getResult().getOutput().getText();
         
         return new TranslateResponse(translatedText);
+	}
+
+	/**
+	 * Markdown文件翻译服务
+	 * @param file 需要翻译的md文件
+	 * @param sourceLanguage 源语言
+	 * @param targetLanguage 目标语言
+	 * @return 翻译后的md文件
+     */
+	@PostMapping("/markdown-file")
+	public TranslateResponse translateMarkdownFile(
+			@RequestParam("file") MultipartFile file,
+			@RequestParam(defaultValue = "英文") String sourceLanguage,
+			@RequestParam(defaultValue = "中文") String targetLanguage) throws IOException {
+
+		Path tempFile = Files.createTempFile("markdown_", ".md");
+		file.transferTo(tempFile);
+
+		try {
+			String translatedPath = markdownTranslationService.translateMarkdownFile(
+					tempFile.toString(),
+					sourceLanguage,
+					targetLanguage
+			);
+			String translatedContent = Files.readString(Paths.get(translatedPath));
+			System.out.println(translatedContent);
+			return new TranslateResponse(
+					"success"
+			);
+		} finally {
+			Files.deleteIfExists(tempFile);
+		}
 	}
 } 

--- a/spring-ai-alibaba-translate-example/src/main/java/com/alibaba/example/translate/controller/service/MarkdownTranslationService.java
+++ b/spring-ai-alibaba-translate-example/src/main/java/com/alibaba/example/translate/controller/service/MarkdownTranslationService.java
@@ -1,0 +1,96 @@
+package com.alibaba.example.translate.controller.service;
+
+import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
+import com.alibaba.cloud.ai.dashscope.chat.DashScopeChatModel;
+import com.alibaba.cloud.ai.dashscope.chat.DashScopeChatOptions;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.core.io.Resource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+
+/**
+ * Description: 文件翻译
+ * Author: yhong
+ * @since 1.0.0-M2
+ */
+@Service
+public class MarkdownTranslationService {
+
+    private final DashScopeChatModel dashScopeChatModel;
+
+    @Value("classpath:/prompts/markdown-translation-prompt.st")
+    private Resource markdownPromptResource;
+
+    public MarkdownTranslationService(DashScopeChatModel dashScopeChatModel) {
+        this.dashScopeChatModel = dashScopeChatModel;
+    }
+
+    public String translateMarkdownFile(String filePath,
+                                        String sourceLanguage,
+                                        String targetLanguage) throws IOException {
+        // 1. 读取原始Markdown文件
+        String originalContent = Files.readString(Paths.get(filePath));
+
+        // 2. 加载Prompt模板
+        PromptTemplate promptTemplate = new PromptTemplate(markdownPromptResource);
+        Map<String, Object> params = Map.of(
+                "sourceLanguage", sourceLanguage,
+                "targetLanguage", targetLanguage,
+                "markdownContent", originalContent
+        );
+
+        // 3. 构建翻译Prompt
+        Prompt prompt = new Prompt(
+                String.valueOf(promptTemplate.create(params)),
+                buildTranslationOptions()
+        );
+
+        // 4. 调用大模型翻译
+        String translatedContent = dashScopeChatModel.call(prompt)
+                .getResult().getOutput().getText();
+
+        // 5. 保存文件到本地（桌面）
+        return saveTranslatedFile(filePath, translatedContent);
+    }
+
+    private DashScopeChatOptions buildTranslationOptions() {
+        return DashScopeChatOptions.builder()
+                .withModel(DashScopeApi.ChatModel.QWEN_PLUS.getModel())
+                .withTopP(0.7)
+                .withTopK(50)
+                .withTemperature(0.3)
+                .build();
+    }
+
+    private String saveTranslatedFile(String originalPath, String content) throws IOException {
+        // 1. 输出目录存在（~/Desktop/translated）
+        Path outputDir = Paths.get(System.getProperty("user.home"), "Desktop", "translated");
+        Files.createDirectories(outputDir);
+
+        // 2. 构建新文件名
+        String originalFilename = Paths.get(originalPath).getFileName().toString();
+        String newFilename = originalFilename.replaceAll("\\.md$", "") + "_zh.md"; // 确保去除原.md后缀
+        Path outputPath = outputDir.resolve(newFilename);
+
+        // 3. 写入内容（覆盖已存在文件）
+        Files.writeString(
+                outputPath,
+                content,
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE
+        );
+
+        return outputPath.toString();
+    }
+}

--- a/spring-ai-alibaba-translate-example/src/main/resources/prompts/markdown-translation-prompt.st
+++ b/spring-ai-alibaba-translate-example/src/main/resources/prompts/markdown-translation-prompt.st
@@ -1,0 +1,9 @@
+你是一名专业的翻译引擎，请严格按照以下要求处理Markdown文件：
+1. 将以下Markdown内容从{sourceLanguage}翻译为{targetLanguage}，保持原有格式不变
+2. 保留所有Markdown语法（如#标题、**加粗**、`代码块`等）
+3. 不要翻译代码块中的内容（```包裹的内容）
+4. 不要翻译URL链接和路径
+5. 技术术语保持英文原样（如Kubernetes、React等）
+
+需要翻译的内容：
+{markdownContent}


### PR DESCRIPTION
✅ 变更内容
新增了一个文件翻译接口以及对应的prompt示例，用于展示如何调用dashscope实现文件内容的自动翻译。


💡 背景说明
在使用Ollama进行翻译时， 我注意到有文件翻译示例， 但是dashscope中并没有， 故补充。


