### PR TITLE
添加多平台多模型聊天示例

### DIFF
--- a/spring-ai-alibaba-more-platform-and-model-example/src/main/java/com/alibaba/ai/examples/controller/client/MorePlatformAndMoreModelChatClientController.java
+++ b/spring-ai-alibaba-more-platform-and-model-example/src/main/java/com/alibaba/ai/examples/controller/client/MorePlatformAndMoreModelChatClientController.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ai.examples.controller.client;
+
+import com.alibaba.cloud.ai.dashscope.chat.DashScopeChatOptions;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author liu-657667
+ * @author <a href="mailto:liu-657667@qq.com">liu-657667</a>
+ */
+
+@RestController
+@RequestMapping("/more-platform-and-more-model-chat-client")
+public class MorePlatformAndMoreModelChatClientController {
+
+    private final ChatClient chatClient;
+
+    private final ChatModel dashScopeChatModel;
+
+    private final ChatModel ollamaChatModel;
+
+    private final ChatModel openAIChatModel;
+
+    private final Set<String> modelList = Set.of(
+            "deepseek-r1",
+            "deepseek-v3",
+            "qwen-plus",
+            "qwen-max"
+    );
+    private final Set<String> ollamaModelList = Set.of("deepseek-r1:1.5b");
+    private final Set<String> openaiModelList = Set.of("gpt-4.1");
+
+    Map<String, Set<String>> modelMap = Map.of(
+            "dashscope", modelList,
+            "ollama", ollamaModelList,
+            "openai", openaiModelList
+    );
+
+    public MorePlatformAndMoreModelChatClientController(
+            @Qualifier("dashscopeChatModel") ChatModel dashScopeChatModel,
+            @Qualifier("ollamaChatModel") ChatModel ollamaChatModel,
+            @Qualifier("openAiChatModel") ChatModel openAIChatModel
+    ) {
+
+        this.dashScopeChatModel = dashScopeChatModel;
+        this.ollamaChatModel = ollamaChatModel;
+        this.openAIChatModel = openAIChatModel;
+
+        // 默认使用 DashScopeChatModel 构建
+        this.chatClient = ChatClient.builder(dashScopeChatModel).build();
+    }
+
+    @GetMapping
+    public Flux<String> stream(
+            @RequestParam("prompt") String prompt,
+            @RequestHeader(value = "platform", required = false) String platform,
+            @RequestHeader(value = "models", required = false) String models
+    ) {
+
+        if (!StringUtils.hasText(platform)) {
+            return Flux.just("platform not exist");
+        }
+
+        if (CollectionUtils.isEmpty(modelMap.get(platform)) || !modelMap.get(platform).contains(models)) {
+            return Flux.just("model not exist");
+        }
+
+        if (Objects.equals("dashscope", platform)) {
+            System.out.println("命中 dashscope ......");
+            return chatClient.prompt(prompt).options(
+                    DashScopeChatOptions.builder()
+                            .withModel(models)
+                            .build()
+            ).stream().content();
+        }
+
+        if (Objects.equals("ollama", platform)) {
+            System.out.println("命中 ollama ......");
+            return ChatClient.builder(ollamaChatModel).build()
+                    .prompt(
+                            new Prompt(prompt, ChatOptions.builder().model(models).build())
+                    )
+                    .stream().content();
+        }
+
+        if (Objects.equals("openai", platform)) {
+            System.out.println("命中 openai ......");
+            return ChatClient.builder(openAIChatModel).build()
+                    .prompt(
+                            new Prompt(prompt, ChatOptions.builder().model(models).build())
+                    )
+                    .stream().content();
+        }
+
+        return Flux.just("platform not exist");
+    }
+
+}

--- a/spring-ai-alibaba-more-platform-and-model-example/src/main/java/com/alibaba/ai/examples/controller/model/MorePlatformAndMoreModelController.java
+++ b/spring-ai-alibaba-more-platform-and-model-example/src/main/java/com/alibaba/ai/examples/controller/model/MorePlatformAndMoreModelController.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ai.examples.controller.model;
+
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author liu-657667
+ * @author <a href="mailto:liu-657667@qq.com">liu-657667</a>
+ */
+
+@RestController
+@RequestMapping("no-platform")
+public class MorePlatformAndMoreModelController {
+
+    private final ChatModel dashScopeChatModel;
+
+    private final ChatModel ollamaChatModel;
+    private final ChatModel openAIChatModel;
+
+    private final Set<String> modelList = Set.of(
+            "deepseek-r1",
+            "deepseek-v3",
+            "qwen-plus",
+            "qwen-max"
+    );
+    private final Set<String> ollamaModelList = Set.of("deepseek-r1:1.5b");
+    private final Set<String> openaiModelList = Set.of("gpt-4.1");
+
+    Map<String, Set<String>> modelMap = Map.of(
+            "dashscope", modelList,
+            "ollama", ollamaModelList,
+            "openai", openaiModelList
+    );
+    /**
+    * @Description: @Qualifier注解是用来指定注入的bean的名字，value值需要到源码中查看，如不对应会报错：NoSuchBeanDefinitionException
+     * 如openAiChatModel的路径见：org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration.java
+    */
+    public MorePlatformAndMoreModelController(
+            @Qualifier("dashscopeChatModel") ChatModel dashScopeChatModel,
+            @Qualifier("ollamaChatModel") ChatModel OllamaChatModel,
+            @Qualifier("openAiChatModel") ChatModel openAIChatModel
+    ) {
+        this.dashScopeChatModel = dashScopeChatModel;
+        this.ollamaChatModel = OllamaChatModel;
+        this.openAIChatModel = openAIChatModel;
+    }
+
+    @GetMapping("/{platform}/{models}/{prompt}")
+    public String chat(
+            @PathVariable("platform") String platform,
+            @PathVariable("models") String models,
+            @PathVariable("prompt") String prompt
+    ) {
+
+        System.out.println("===============================================");
+        System.out.println("DashScope Model：" + dashScopeChatModel.toString());
+        System.out.println("Ollama Model：" + ollamaChatModel.toString());
+        System.out.println("OpenAI Model：" + openAIChatModel.toString());
+        System.out.println("===============================================");
+        if (CollectionUtils.isEmpty(modelMap.get(platform)) || !modelMap.get(platform).contains(models)) {
+            return "model not exist";
+        }
+        ChatOptions runtimeOptions = ChatOptions.builder().model(models).build();
+        if ("dashscope".equals(platform)) {
+            return dashScopeChatModel.call(new Prompt(prompt, runtimeOptions))
+                    .getResult().getOutput().getText();
+        }
+
+        if ("ollama".equals(platform)) {
+            return ollamaChatModel.call(new Prompt(prompt, runtimeOptions))
+                    .getResult().getOutput().getText();
+        }
+
+        if ("openAI".equals(platform)) {
+            return openAIChatModel.call(new Prompt(prompt, runtimeOptions))
+                    .getResult().getOutput().getText();
+        }
+        return "Error ...";
+    }
+
+}


### PR DESCRIPTION
- 新增 MorePlatformAndMoreModelChatClientController 和 MorePlatformAndMoreModelController
- 实现了对 DashScope、Ollama 和 OpenAI平台的支持
- 提供了流式和非流式的聊天接口
- 集成了模型验证和动态选择功能

## What does this PR do?

> For example: `Feat: Add DashScope LLMs chat example`
