### PR TITLE
ToolCallbackProvider bean not found when upgrading to M8

### DIFF
--- a/spring-ai-alibaba-mcp-example/starter-example/client/starter-webflux-client/src/main/java/org/springframework/ai/mcp/samples/client/Application.java
+++ b/spring-ai-alibaba-mcp-example/starter-example/client/starter-webflux-client/src/main/java/org/springframework/ai/mcp/samples/client/Application.java
@@ -19,7 +19,6 @@ package org.springframework.ai.mcp.samples.client;
 
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.tool.ToolCallbackProvider;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;


### PR DESCRIPTION
## What does this PR do?

> For example: `Feat: Add DashScope LLMs chat example`

mcp-webflux-client-exmaple 的示例升级到M8之后出现了
a bean of type 'org.springframework.ai.tool.ToolCallbackProvider' that could not be found.

![image](https://github.com/user-attachments/assets/c0a1f4bd-22ea-4670-9e31-2c5cf36a6ab8)
