### PR TITLE
fix mcp client m8

### DIFF
--- a/spring-ai-alibaba-mcp-example/starter-example/client/starter-webflux-client/src/main/resources/application.yml
+++ b/spring-ai-alibaba-mcp-example/starter-example/client/starter-webflux-client/src/main/resources/application.yml
@@ -16,6 +16,8 @@ spring:
       api-key: ${DASH_SCOPE_API_KEY}
     mcp:
       client:
+        toolcallback:
+          enabled: true
         sse:
           connections:
             server1:


### PR DESCRIPTION
## What does this PR do?
fix this:
a bean of type 'org.springframework.ai.tool.ToolCallbackProvider' that could not be found.


> For example: `Feat: Add DashScope LLMs chat example`
