### PR TITLE
fix: specify <Void> in Mono.defer to fix type mismatch error

### DIFF
--- a/spring-ai-alibaba-mcp-example/spring-ai-alibaba-mcp-starter-example/client/mcp-stremable-client-example/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
+++ b/spring-ai-alibaba-mcp-example/spring-ai-alibaba-mcp-starter-example/client/mcp-stremable-client-example/src/main/java/io/modelcontextprotocol/spec/McpClientSession.java
@@ -289,7 +289,7 @@ public class McpClientSession implements McpSession {
 	 */
 	@Override
 	public Mono<Void> closeGracefully() {
-		return Mono.defer(() -> {
+		return Mono.<Void>defer(() -> {
 			this.connection.dispose();
 			return transport.closeGracefully();
 		});


### PR DESCRIPTION
## What does this PR do?

> For example: `Feat: Add DashScope LLMs chat example`
