### PR TITLE
Fix:SpringBoot3.4版本之后与knife4j不兼容，文档接口文档页面无法打开问题修复

### DIFF
--- a/spring-ai-alibaba-playground/pom.xml
+++ b/spring-ai-alibaba-playground/pom.xml
@@ -25,7 +25,7 @@
 		<jackson.version>2.15.0</jackson.version>
 		<hibernate.version>6.6.9.Final</hibernate.version>
 		<sqlite-jdbc.version>3.49.1.0</sqlite-jdbc.version>
-		<knife4j.version>4.4.0</knife4j.version>
+		<knife4j.version>4.6.0</knife4j.version>
 		<javacv-platform.version>1.5.9</javacv-platform.version>
 
 		<maven.compiler.source>17</maven.compiler.source>
@@ -146,7 +146,7 @@
 
 		<!-- Swagger API Docs -->
 		<dependency>
-			<groupId>com.github.xiaoymin</groupId>
+			<groupId>com.github.xingfudeshi</groupId>
 			<artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
 			<version>${knife4j.version}</version>
 		</dependency>


### PR DESCRIPTION
解决knife4j接口文档打开报错不现实接口问题，knife4j与当前spring-boot版本不兼容。knife4j官网暂无更新，所以使用其它开发者贡献的knife4j包。