### PR TITLE
feat(spring-ai-alibaba-multi-model-example): 添加 OpenAI模式调用阿里云 DashScope 的多模态模型

### DIFF
--- a/spring-ai-alibaba-multi-model-example/openai-dashscope-multi-model/README.md
+++ b/spring-ai-alibaba-multi-model-example/openai-dashscope-multi-model/README.md
@@ -1,0 +1,70 @@
+# Spring AI Alibaba OpenAI-DashScope 多模态示例
+
+## 项目简介
+本项目演示如何通过 **Spring AI** 的 OpenAI 客户端接口调用阿里云 **DashScope** 的多模态模型（如 `qwen-vl-max-latest`），实现图片分析功能。
+虽然依赖了 Spring AI 的 OpenAI 模块，但底层实际调用的是 DashScope 的兼容模式接口。
+
+---
+
+## 核心功能
+1. **图片 URL 分析** 
+   通过 GET 请求传入图片 URL 和描述文本，由 DashScope 多模态模型分析图片内容。
+2. **图片文件上传分析** 
+   通过 POST 请求上传本地图片文件，结合提示词进行多模态分析。
+
+---
+
+## 技术架构
+- **框架**：Spring Boot 3.x + Spring AI OpenAI Starter
+- **多模态模型**：阿里云 DashScope 的 `qwen-vl-max-latest`
+- **核心类**：
+  - [OpenAiChatClientController](file://D:\\mxy\\qisheng\\workspace\\mxy-git-workspace\\spring-ai-alibaba-examples\\spring-ai-alibaba-multi-model-example\\openai-dashscope-multi-model\\src\\main\\java\\com\\alibaba\\cloud\\ai\\example\\multi\\controller\\OpenAiChatClientController.java#L35-L139)：提供 REST API 接口
+  - `ChatClient`：封装 DashScope 兼容模式的调用逻辑
+
+---
+
+## 环境准备
+1. **API 密钥** 
+   配置阿里云 DashScope 的 API Key：
+   ```bash
+   export AI_DASHSCOPE_API_KEY=your_api_key_here
+   ```
+2. **依赖服务** 
+   无需额外依赖，DashScope 服务通过公网访问。
+
+---
+
+## 快速启动
+1. **构建项目** 
+   ```bash
+   mvn clean install
+   ```
+2. **运行服务** 
+   ```bash
+   cd openai-dashscope-multi-model
+   mvn spring-boot:run
+   ```
+3. **访问接口** 
+   服务启动后，默认监听端口 `10014`。
+---
+
+## 特性说明
+1. **多模态兼容性** 
+   通过以下配置切换 DashScope 多模态模型：
+   ```yaml
+   spring:
+     ai:
+       openai:
+         base-url: https://dashscope.aliyuncs.com/compatible-mode  # DashScope 兼容模式
+         chat:
+           options:
+             model: qwen-vl-max-latest  # DashScope 多模态模型
+   ```
+2. **文件上传限制** 
+   默认支持最大 10MB 文件上传，可通过 `application.yml` 修改：
+   ```yaml
+   spring:
+     servlet:
+       multipart:
+         max-file-size: 10MB
+   ```

--- a/spring-ai-alibaba-multi-model-example/openai-dashscope-multi-model/pom.xml
+++ b/spring-ai-alibaba-multi-model-example/openai-dashscope-multi-model/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alibaba.cloud.ai</groupId>
+        <artifactId>spring-ai-alibaba-multi-model-example</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>openai-dashscope-multi-model</artifactId>
+    <packaging>jar</packaging>
+    <description>Spring AI Alibaba OPENAI Dashscope Multi Model Example</description>
+    <name>Spring AI Alibaba OPENAI Dashscope Multi Model Examples</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Spring AI OpenAI Starter -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-openai</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/spring-ai-alibaba-multi-model-example/openai-dashscope-multi-model/src/main/java/com/alibaba/cloud/ai/example/multi/OpenAiDashScopeMultiModelApplication.java
+++ b/spring-ai-alibaba-multi-model-example/openai-dashscope-multi-model/src/main/java/com/alibaba/cloud/ai/example/multi/OpenAiDashScopeMultiModelApplication.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.example.multi;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class OpenAiDashScopeMultiModelApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(OpenAiDashScopeMultiModelApplication.class, args);
+    }
+}

--- a/spring-ai-alibaba-multi-model-example/openai-dashscope-multi-model/src/main/java/com/alibaba/cloud/ai/example/multi/controller/OpenAiChatClientController.java
+++ b/spring-ai-alibaba-multi-model-example/openai-dashscope-multi-model/src/main/java/com/alibaba/cloud/ai/example/multi/controller/OpenAiChatClientController.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.example.multi.controller;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.SimpleLoggerAdvisor;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.util.MimeTypeUtils;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URI;
+
+/**
+ * @author xiaoyu Miao
+ */
+@RestController
+@RequestMapping("openai/client")
+public class OpenAiChatClientController {
+
+    private final ChatClient chatClient;
+
+    public OpenAiChatClientController(@Qualifier("openAiChatModel") ChatModel chatModel) {
+        chatClient = ChatClient.builder(chatModel)
+                .defaultAdvisors(new SimpleLoggerAdvisor())
+                .defaultOptions(OpenAiChatOptions.builder().temperature(0.7).build())
+                .build();
+    }
+
+
+    /**
+     * 图片分析接口 - 通过 URL
+     * 使用 OpenAI 多模态模型分析图片内容
+     */
+    @GetMapping("/image/analyze/url")
+    public String analyzeImageByUrl(@RequestParam(defaultValue = "请分析这张图片的内容") String prompt,
+                                    @RequestParam String imageUrl) {
+        try {
+            // 创建包含图片的用户消息
+            String mineType = determineMimeTypeFromUrl(imageUrl);
+            Media media = Media.builder()
+                    .data(new URI(imageUrl))
+                    .mimeType(MimeTypeUtils.parseMimeType(mineType))
+                    .build();
+            UserMessage message = UserMessage.builder()
+                    .text(prompt)
+                    .media(media)
+                    .build();
+
+            // 创建提示词，使用 OpenAI 多模态模型
+            Prompt chatPrompt = new Prompt(message,
+                    OpenAiChatOptions.builder()
+                            .model("qwen-vl-max-latest")  // 使用 OpenAI 视觉模型
+                            .temperature(0.7)
+                            .maxTokens(1000)
+                            .build());
+            // 调用模型进行图片分析
+            return chatClient.prompt(chatPrompt).call().content();
+        } catch (Exception e) {
+            return "图片分析失败: " + e.getMessage();
+        }
+    }
+
+    /**
+     * 图片分析接口 - 通过文件上传
+     */
+    @PostMapping("/image/analyze/upload")
+    public String analyzeImageByUpload(@RequestParam(defaultValue = "请分析这张图片的内容") String prompt,
+                                       @RequestParam("file") MultipartFile file) {
+        try {
+            // 验证文件类型
+            if (!file.getContentType().startsWith("image/")) {
+                return "请上传图片文件";
+            }
+
+            // 创建包含图片的用户消息
+            Media media = new Media(MimeTypeUtils.parseMimeType(file.getContentType()), file.getResource());
+            UserMessage message = UserMessage.builder()
+                    .text(prompt)
+                    .media(media)
+                    .build();
+
+            // 创建提示词，启用多模态模型
+            // 创建提示词，使用 OpenAI 多模态模型
+            Prompt chatPrompt = new Prompt(message,
+                    OpenAiChatOptions.builder()
+                            .model("qwen-vl-max-latest")  // 使用 OpenAI 视觉模型
+                            .temperature(0.7)
+                            .maxTokens(1000)
+                            .build());
+
+            // 调用模型进行图片分析
+            return chatClient.prompt(chatPrompt).call().content();
+
+        } catch (Exception e) {
+            return "图片分析失败: " + e.getMessage();
+        }
+    }
+
+
+    /**
+     * 根据URL确定MIME类型
+     * @param imageUrl 图片URL
+     * @return MIME类型字符串
+     */
+    private String determineMimeTypeFromUrl(String imageUrl) {
+        String lowerUrl = imageUrl.toLowerCase();
+        if (lowerUrl.endsWith(".jpg") || lowerUrl.endsWith(".jpeg")) {
+            return "image/jpeg";
+        } else if (lowerUrl.endsWith(".png")) {
+            return "image/png";
+        } else if (lowerUrl.endsWith(".gif")) {
+            return "image/gif";
+        } else if (lowerUrl.endsWith(".webp")) {
+            return "image/webp";
+        } else {
+            // 默认使用JPEG
+            return "image/jpeg";
+        }
+    }
+}

--- a/spring-ai-alibaba-multi-model-example/openai-dashscope-multi-model/src/main/resources/application.yml
+++ b/spring-ai-alibaba-multi-model-example/openai-dashscope-multi-model/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+server:
+  port: 10014
+
+spring:
+  application:
+    name: spring-ai-alibaba-dashscope-chat-example
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+  ai:
+    openai:
+      api-key: ${AI_DASHSCOPE_API_KEY}
+      base-url: https://dashscope.aliyuncs.com/compatible-mode
+      chat:
+        options:
+          model: qwen-plus-latest

--- a/spring-ai-alibaba-multi-model-example/pom.xml
+++ b/spring-ai-alibaba-multi-model-example/pom.xml
@@ -38,6 +38,7 @@
 	<modules>
 		<module>dashscope-multi-model</module>
 		<module>ark-multi-model</module>
+		<module>openai-dashscope-multi-model</module>
 	</modules>
 
 	<build>


### PR DESCRIPTION
- 新增 openai-dashscope-multi-model 模块
- 实现了基于 Spring AI OpenAI Starter 的图片分析功能
- 提供了通过 URL 和文件上传两种方式调用多模态模型的接口
- 配置了 DashScope 兼容模式和相应的 API Key
- 添加了详细的 README 文档说明项目结构和使用方法

## What does this PR do?

> For example: `Feat: Add DashScope LLMs chat example`
