### PR TITLE
fix(reason-chat-memory): fix missing chat conversation_id in Reason Mode

### DIFF
--- a/spring-ai-alibaba-playground/src/main/java/com/alibaba/cloud/ai/application/advisor/ReasoningContentAdvisor.java
+++ b/spring-ai-alibaba-playground/src/main/java/com/alibaba/cloud/ai/application/advisor/ReasoningContentAdvisor.java
@@ -85,7 +85,7 @@ public class ReasoningContentAdvisor implements BaseAdvisor {
 					}).toList();
 			
 			ChatResponse thinkChatResp = ChatResponse.builder().from(resp).generations(thinkGenerations).build();
-			return ChatClientResponse.builder().chatResponse(thinkChatResp).build();
+			return ChatClientResponse.builder().context(chatClientResponse.context()).chatResponse(thinkChatResp).build();
 			
 		}
 		


### PR DESCRIPTION
## What does this PR do?

Fix: missing chat conversation_id in Reason Mode

修复：推理模式丢失会话id，一直使用"default"作为会话id
