### PR TITLE
fix ToolCallAutoConfiguration Error

### DIFF
--- a/spring-ai-alibaba-tool-calling-example/src/main/java/com/alibaba/cloud/ai/toolcall/config/ToolCallAutoConfiguration.java
+++ b/spring-ai-alibaba-tool-calling-example/src/main/java/com/alibaba/cloud/ai/toolcall/config/ToolCallAutoConfiguration.java
@@ -30,6 +30,10 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnClass(GetCurrentTimeByTimeZoneIdService.class)
 public class ToolCallAutoConfiguration {
+    @Bean
+    public GetCurrentTimeByTimeZoneIdService getCurrentTimeByTimeZoneIdService() {
+        return new GetCurrentTimeByTimeZoneIdService();
+    }
 
     @Bean
     public TimeTools timeTools(GetCurrentTimeByTimeZoneIdService service) {


### PR DESCRIPTION
## What does this PR do?

> fix ToolCallAutoConfiguration Error
GetCurrentTimeByTimeZoneIdService should Bean in classpath and can be instantiated.
