### PR TITLE
修复knife4j接口文档中重名问题，导致的方法归类错误

### DIFF
--- a/spring-ai-alibaba-playground/src/main/java/com/alibaba/cloud/ai/application/controller/SAAMcpController.java
+++ b/spring-ai-alibaba-playground/src/main/java/com/alibaba/cloud/ai/application/controller/SAAMcpController.java
@@ -60,7 +60,7 @@ public class SAAMcpController {
 	@UserIp
 	@GetMapping("/inner/mcp")
 	@Operation(summary = "DashScope MCP Chat")
-	public Result<ToolCallResp> chat(
+	public Result<ToolCallResp> mcpChat(
 			@Validated @RequestParam("prompt") String prompt
 	) {
 

--- a/spring-ai-alibaba-playground/src/main/java/com/alibaba/cloud/ai/application/controller/SAAToolsController.java
+++ b/spring-ai-alibaba-playground/src/main/java/com/alibaba/cloud/ai/application/controller/SAAToolsController.java
@@ -54,7 +54,7 @@ public class SAAToolsController {
 	@UserIp
 	@GetMapping("/tool-call")
 	@Operation(summary = "DashScope ToolCall Chat")
-	public Result<ToolCallResp> chat(
+	public Result<ToolCallResp> toolCallChat(
 			@Validated @RequestParam("prompt") String prompt
 	) {
 


### PR DESCRIPTION
knife4j 接口文档错误
描述：在knife4j 接口文档中，发现了三个接口，有两个驴头不对马嘴，非常奇怪。
 
<img width="678" height="650" alt="C6014BAA-D49E-4BF0-B547-11A4A78CDA75" src="https://github.com/user-attachments/assets/ae9da9fc-855c-483f-b690-05b956094d72" />
<img width="678" height="650" alt="5BEC4F16-3548-4D2D-ABAF-16200F8E7725" src="https://github.com/user-attachments/assets/414807c4-61c9-448d-a516-eca4ecb5acc8" />
<img width="847" height="399" alt="2EFE7309-FB3B-4556-BAFD-BA730FBD7F3B" src="https://github.com/user-attachments/assets/61b5288d-4e25-4f7a-bcde-ea9c88bb451c" />

代码走查发现，这里存在很明显的错误：
DashScope Flux Chat 对应的接口应当是/api/v1
 
DashScope ToolCall Chat 对应的接口应当是/api/tool-call

而以上两个接口，在knife4j文档中被定位到DashScope MCP Chat，对应的接口是/inner/mcp

观察到，以上三个接口的方法名是相同的，都是chat。命名相同造成knife4j对接口的错误识别。
解决方法：对上述三个接口重命名，采用不同的方法名：chat、mcpChat、toolCallChat。