### PR TITLE
feat(bailian): 添加百炼大模型调用示例

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
 		<module>spring-ai-alibaba-nl2sql-example</module>
 		<module>spring-ai-alibaba-studio-example</module>
 		<module>spring-ai-alibaba-graph-example</module>
+		<module>spring-ai-alibaba-bailian-example</module>
 	</modules>
 
 	<dependencyManagement>

--- a/spring-ai-alibaba-bailian-example/pom.xml
+++ b/spring-ai-alibaba-bailian-example/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+   Copyright 2023-2024 the original author or authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alibaba.cloud.ai</groupId>
+        <artifactId>spring-ai-alibaba-examples</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <version>${revision}</version>
+    <artifactId>spring-ai-alibaba-bailian-example</artifactId>
+    <description>Spring AI Alibaba Bailian Example</description>
+    <name>Spring AI Alibaba Bailian Examples</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+        <!-- utils -->
+        <commons-lang3.version>3.14.0</commons-lang3.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>${spring-ai.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba.cloud.ai</groupId>
+                <artifactId>spring-ai-alibaba-starter-dashscope</artifactId>
+                <version>${spring-ai-alibaba.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.cloud.ai</groupId>
+            <artifactId>spring-ai-alibaba-starter-dashscope</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>${maven-deploy-plugin.version}</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-ai-alibaba-bailian-example/src/main/java/com/alibaba/cloud/ai/example/bailian/BailianExampleApplication.java
+++ b/spring-ai-alibaba-bailian-example/src/main/java/com/alibaba/cloud/ai/example/bailian/BailianExampleApplication.java
@@ -1,0 +1,29 @@
+/*
+* Copyright 2024 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.alibaba.cloud.ai.example.bailian;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BailianExampleApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(BailianExampleApplication.class, args);
+	}
+
+}

--- a/spring-ai-alibaba-bailian-example/src/main/java/com/alibaba/cloud/ai/example/bailian/knowledge/config/BailianAutoconfiguration.java
+++ b/spring-ai-alibaba-bailian-example/src/main/java/com/alibaba/cloud/ai/example/bailian/knowledge/config/BailianAutoconfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.example.bailian.knowledge.config;
+
+import com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionProperties;
+import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * @author yuluo
+ * @author <a href="mailto:yuluo08290126@gmail.com">yuluo</a>
+ */
+
+@AutoConfiguration
+@EnableConfigurationProperties({
+		DashScopeConnectionProperties.class
+})
+public class BailianAutoconfiguration {
+
+	/**
+	 * 百炼调用时需要配置 DashScope API，对 dashScopeApi 强依赖。
+	 * @return
+	 */
+	@Bean
+	public DashScopeApi dashScopeApi(DashScopeConnectionProperties connectionProperties) {
+		
+		return DashScopeApi.builder().apiKey(connectionProperties.getApiKey()).build();
+	}
+
+}

--- a/spring-ai-alibaba-bailian-example/src/main/java/com/alibaba/cloud/ai/example/bailian/knowledge/controller/CloudRagController.java
+++ b/spring-ai-alibaba-bailian-example/src/main/java/com/alibaba/cloud/ai/example/bailian/knowledge/controller/CloudRagController.java
@@ -1,0 +1,56 @@
+/*
+* Copyright 2024 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.alibaba.cloud.ai.example.bailian.knowledge.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.alibaba.cloud.ai.example.bailian.knowledge.service.RagService;
+import reactor.core.publisher.Flux;
+
+/**
+ * Title Cloud rag controller.<br>
+ * Description Cloud rag controller.<br>
+ *
+ * @author yuanci.ytb
+ * @since 1.0.0-M2
+ */
+
+@RestController
+@RequestMapping("/ai")
+public class CloudRagController {
+
+	private final RagService cloudRagService;
+
+	public CloudRagController(RagService cloudRagService) {
+		this.cloudRagService = cloudRagService;
+	}
+
+	@GetMapping("/bailian/knowledge/importDocument")
+	public void importDocument() {
+		cloudRagService.importDocuments();
+	}
+
+	@GetMapping("/bailian/knowledge/generate")
+	public Flux<String> generate(@RequestParam(value = "message",
+			defaultValue = "你好，请问你的知识库文档主要是关于什么内容的?") String message) {
+		return cloudRagService.retrieve(message).map(x -> x.getResult().getOutput().getText());
+	}
+
+}

--- a/spring-ai-alibaba-bailian-example/src/main/java/com/alibaba/cloud/ai/example/bailian/knowledge/service/CloudRagService.java
+++ b/spring-ai-alibaba-bailian-example/src/main/java/com/alibaba/cloud/ai/example/bailian/knowledge/service/CloudRagService.java
@@ -1,0 +1,124 @@
+/*
+* Copyright 2024 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.alibaba.cloud.ai.example.bailian.knowledge.service;
+
+import com.alibaba.cloud.ai.advisor.DocumentRetrievalAdvisor;
+import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
+import com.alibaba.cloud.ai.dashscope.rag.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.SystemPromptTemplate;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentReader;
+import org.springframework.ai.rag.retrieval.search.DocumentRetriever;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * Title Cloud rag service.<br>
+ * Description Cloud rag service.<br>
+ *
+ * @author yuanci.ytb
+ * @since 1.0.0-M2
+ */
+
+@Service()
+public class CloudRagService implements RagService {
+
+	private static final Logger logger = LoggerFactory.getLogger(CloudRagService.class);
+
+	private static final String indexName = "微服务";
+
+	@Value("classpath:/data/spring_ai_alibaba_quickstart.pdf")
+	private Resource springAiResource;
+
+	private static final String retrievalSystemTemplate = """
+			Context information is below.
+			---------------------
+			{question_answer_context}
+			---------------------
+			Given the context and provided history information and not prior knowledge,
+			reply to the user comment. If the answer is not in the context, inform
+			the user that you can't answer the question.
+			""";
+
+	private final ChatClient chatClient;
+
+	private final DashScopeApi dashscopeApi;
+
+	public CloudRagService(ChatClient.Builder builder, DashScopeApi dashscopeApi) {
+		DocumentRetriever retriever = new DashScopeDocumentRetriever(dashscopeApi,
+				DashScopeDocumentRetrieverOptions.builder().withIndexName(indexName).build());
+
+		this.dashscopeApi = dashscopeApi;
+		this.chatClient = builder
+				.defaultAdvisors(new DocumentRetrievalAdvisor(retriever, new SystemPromptTemplate(retrievalSystemTemplate)))
+				.build();
+	}
+
+	@Override
+	public void importDocuments() {
+		String path = saveToTempFile(springAiResource);
+
+		// 1. import and split documents
+		DocumentReader reader = new DashScopeDocumentCloudReader(path, dashscopeApi, null);
+		List<Document> documentList = reader.get();
+		logger.info("{} documents loaded and split", documentList.size());
+
+		// 1. add documents to DashScope cloud storage
+		VectorStore vectorStore = new DashScopeCloudStore(dashscopeApi, new DashScopeStoreOptions(indexName));
+		vectorStore.add(documentList);
+		logger.info("{} documents added to dashscope cloud vector store", documentList.size());
+	}
+
+	private String saveToTempFile(Resource springAiResource) {
+		try {
+			File tempFile = File.createTempFile("spring_ai_alibaba_quickstart", ".pdf");
+			tempFile.deleteOnExit();
+
+			try (InputStream inputStream = springAiResource.getInputStream();
+					FileOutputStream outputStream = new FileOutputStream(tempFile)) {
+				byte[] buffer = new byte[4096];
+				int bytesRead;
+				while ((bytesRead = inputStream.read(buffer)) != -1) {
+					outputStream.write(buffer, 0, bytesRead);
+				}
+			}
+
+			return tempFile.getAbsolutePath();
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public Flux<ChatResponse> retrieve(String message) {
+		return chatClient.prompt().user(message).stream().chatResponse();
+	}
+
+}

--- a/spring-ai-alibaba-bailian-example/src/main/java/com/alibaba/cloud/ai/example/bailian/knowledge/service/RagService.java
+++ b/spring-ai-alibaba-bailian-example/src/main/java/com/alibaba/cloud/ai/example/bailian/knowledge/service/RagService.java
@@ -1,0 +1,35 @@
+/*
+* Copyright 2024 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.alibaba.cloud.ai.example.bailian.knowledge.service;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import reactor.core.publisher.Flux;
+
+/**
+ * Title Rag service.<br>
+ * Description Rag service.<br>
+ *
+ * @author yuanci.ytb
+ * @since 1.0.0-M2
+ */
+
+public interface RagService {
+
+	void importDocuments();
+
+	Flux<ChatResponse> retrieve(String message);
+}

--- a/spring-ai-alibaba-bailian-example/src/main/java/com/alibaba/cloud/ai/example/bailian/longcontext/controller/DocumentAnalysisController.java
+++ b/spring-ai-alibaba-bailian-example/src/main/java/com/alibaba/cloud/ai/example/bailian/longcontext/controller/DocumentAnalysisController.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.example.bailian.longcontext.controller;
+
+import com.alibaba.cloud.ai.advisor.DashScopeDocumentAnalysisAdvisor;
+import com.alibaba.cloud.ai.dashscope.chat.DashScopeChatOptions;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.model.SimpleApiKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.UrlResource;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 分析文件文本内容
+ * @author HunterPorter
+ * @author <a href="mailto:zongpeng_hzp@163.com">HunterPorter</a>
+ */
+@RestController
+public class DocumentAnalysisController {
+
+	private final ChatClient chatClient;
+
+	private static final String DEFAULT_SUMMARY_PROMPT = "总结文本";
+
+	public DocumentAnalysisController(ChatClient.Builder chatClientBuilder,
+									  @Value("${spring.ai.dashscope.api-key}") String apiKey) {
+		this.chatClient = chatClientBuilder.defaultAdvisors(
+				new DashScopeDocumentAnalysisAdvisor(new SimpleApiKey(apiKey))
+		).build();
+	}
+
+	@PostMapping(path = "/analyzeByUpload", produces = "text/plain")
+	public String analyzeByUpload(@RequestParam("file") MultipartFile file) {
+
+		return chatClient.prompt()
+				.advisors(a -> a.param(DashScopeDocumentAnalysisAdvisor.RESOURCE, file.getResource()))
+				.user(DEFAULT_SUMMARY_PROMPT)
+				.options(DashScopeChatOptions.builder().withModel("qwen-long").build())
+				.call()
+				.content();
+	}
+
+	@GetMapping(path = "/analyzeByUrl", produces = "text/plain")
+	public String analyzeByUrl(@RequestParam("url") String url) {
+
+		return chatClient.prompt()
+				.advisors(a -> a.param(DashScopeDocumentAnalysisAdvisor.RESOURCE, UrlResource.from(url)))
+				.user(DEFAULT_SUMMARY_PROMPT)
+				.options(DashScopeChatOptions.builder().withModel("qwen-long").build())
+				.call()
+				.content();
+	}
+
+}

--- a/spring-ai-alibaba-bailian-example/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-ai-alibaba-bailian-example/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.alibaba.cloud.ai.example.bailian.knowledge.config.BailianAutoconfiguration

--- a/spring-ai-alibaba-bailian-example/src/main/resources/application.yml
+++ b/spring-ai-alibaba-bailian-example/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  application:
+    name: spring-ai-alibaba-bailian-example
+
+  ai:
+    dashscope:
+      api-key: ${AI_DASHSCOPE_API_KEY}

--- a/spring-ai-alibaba-bailian-example/src/main/resources/prompts/system-qa.st
+++ b/spring-ai-alibaba-bailian-example/src/main/resources/prompts/system-qa.st
@@ -1,0 +1,7 @@
+Context information is below.
+---------------------
+{question_answer_context}
+---------------------
+Given the context and provided history information and not prior knowledge,
+reply to the user comment. If the answer is not in the context, inform
+the user that you can't answer the question.


### PR DESCRIPTION


## What does this PR do?
添加百炼大模型调用示例

- 新增 spring-ai-alibaba-bailian-example 模块
- 迁入 bailian-rag-knowledge
- 添加了文件上传及分析的example
> For example: `Feat: Add DashScope LLMs chat example`
