### PR TITLE
chore: add env templates to more dashscope examples

### DIFF
--- a/spring-ai-alibaba-chat-example/dashscope-chat/.env.example
+++ b/spring-ai-alibaba-chat-example/dashscope-chat/.env.example
@@ -1,0 +1,2 @@
+# Required
+AI_DASHSCOPE_API_KEY=your_api_key_here

--- a/spring-ai-alibaba-chat-example/qwq-chat/.env.example
+++ b/spring-ai-alibaba-chat-example/qwq-chat/.env.example
@@ -1,0 +1,2 @@
+# Required
+AI_DASHSCOPE_API_KEY=your_api_key_here

--- a/spring-ai-alibaba-helloworld/.env.example
+++ b/spring-ai-alibaba-helloworld/.env.example
@@ -1,0 +1,2 @@
+# Required
+AI_DASHSCOPE_API_KEY=your_api_key_here

--- a/spring-ai-alibaba-image-example/dashscope-image/.env.example
+++ b/spring-ai-alibaba-image-example/dashscope-image/.env.example
@@ -1,0 +1,2 @@
+# Required
+AI_DASHSCOPE_API_KEY=your_api_key_here


### PR DESCRIPTION
## Summary
- add `.env.example` files to a few more DashScope-backed example modules

## Why
Some frequently used examples still require users to infer the needed environment variable from the README or `application.yml`. A tiny template makes local setup more obvious and continues the same low-risk contribution pattern as the existing env-template additions.

## Scope
- add `.env.example` to `spring-ai-alibaba-helloworld`
- add `.env.example` to `spring-ai-alibaba-chat-example/dashscope-chat`
- add `.env.example` to `spring-ai-alibaba-chat-example/qwq-chat`
- add `.env.example` to `spring-ai-alibaba-image-example/dashscope-image`

## Testing
- not run (template-only change)
