### PR TITLE
docs: add common configuration keys reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,14 @@
 | spring-ai-alibaba-rag-example | RAG demo | `mvn -pl spring-ai-alibaba-rag-example spring-boot:run` | vector db (optional by profile) | model api key, embedding model |
 | spring-ai-alibaba-tool-calling-example | tool calling | `mvn -pl spring-ai-alibaba-tool-calling-example spring-boot:run` | none | model api key |
 
+## 常用配置键速查
+
+| 配置键 | 常见模块 | 说明 |
+|---|---|---|
+| `AI_DASHSCOPE_API_KEY` | `spring-ai-alibaba-helloworld`、DashScope chat/image、tool calling、evaluation、很多 graph/rag 示例 | DashScope 兼容模型最常见的 API Key |
+| `OPENAI_API_KEY` | `spring-ai-alibaba-chat-example/openai-chat`、`spring-ai-alibaba-chat-example/vllm-chat` | OpenAI 兼容接口示例常用 |
+| `AI_OPENAI_API_KEY` | `spring-ai-alibaba-image-example/openai-image` | OpenAI 图片生成示例使用 |
+| `AI_DEEPSEEK_API_KEY` | `spring-ai-alibaba-chat-example/deepseek-chat`、`spring-ai-alibaba-mem0-example` | DeepSeek 相关示例使用 |
+| `MINIMAX_API_KEY` | `spring-ai-alibaba-chat-example/minimax-chat` | MiniMax 模型示例使用 |
+| `ZHIPUAI_API_KEY` | `spring-ai-alibaba-chat-example/zhipuai-chat` | 智谱模型示例使用 |
+| `BAIDU_MAP_API_KEY` | `spring-ai-alibaba-tool-calling-example` | 地图工具调用示例需要 |


### PR DESCRIPTION
## Summary
- add a short root README reference for commonly reused configuration keys

## Why
Many modules reuse the same provider and tool keys, but readers currently discover that by opening multiple example directories. A compact reference section should reduce that setup overhead.

## Scope
- add a `常用配置键速查` section to `README.md`
- document common keys such as `AI_DASHSCOPE_API_KEY`, `OPENAI_API_KEY`, and `BAIDU_MAP_API_KEY`
- keep descriptions short and setup-oriented

## Testing
- not run (documentation-only change)
