### PR TITLE
docs: add bilingual troubleshooting for startup issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@
 | spring-ai-alibaba-rag-example | RAG demo | `mvn -pl spring-ai-alibaba-rag-example spring-boot:run` | vector db (optional by profile) | model api key, embedding model |
 | spring-ai-alibaba-tool-calling-example | tool calling | `mvn -pl spring-ai-alibaba-tool-calling-example spring-boot:run` | none | model api key |
 
+## 常见启动问题 / Troubleshooting
+
+- `AI_DASHSCOPE_API_KEY` 未设置 / Missing `AI_DASHSCOPE_API_KEY`: 先确认环境变量已在当前 shell 或 IDE 中生效，再重新启动示例。
+- 端口被占用 / Port already in use: 检查对应模块 `application.yml` 中的 `server.port`，释放端口或改端口后重试。
+- 本地依赖未启动 / Required local services not running: RAG、MCP、向量库或 Docker 相关示例通常需要先启动对应的中间件或容器。
+- 模块里暂时没有 `.env.example` / No `.env.example` in a module yet: 优先查看该模块 README 和 `src/main/resources/application.yml`，确认真实的变量名和依赖服务。


### PR DESCRIPTION
## Summary
- add a short bilingual troubleshooting section for common startup issues

## Why
This repository serves both Chinese-speaking and English-speaking readers. A compact bilingual troubleshooting section can address a few of the most common first-run problems without adding much maintenance burden.

## Scope
- add a `常见启动问题 / Troubleshooting` section to `README.md`
- cover missing env vars, busy ports, local dependency startup, and modules that do not yet have an env template

## Testing
- not run (documentation-only change)
