### PR TITLE
docs: add quickstart matrix to English README

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -17,3 +17,14 @@ For more detailed introductions, please refer to the README.md of each subprojec
 ## How to Contribute
 
 We welcome contributions in any form.
+
+## Quickstart Matrix
+
+| module | purpose | command | required services | env vars | env template | entry |
+|---|---|---|---|---|---|---|
+| spring-ai-alibaba-helloworld | basic chat and advisor examples | `mvn -pl spring-ai-alibaba-helloworld spring-boot:run` | none | `AI_DASHSCOPE_API_KEY` | — | [README](./spring-ai-alibaba-helloworld/README.md) |
+| spring-ai-alibaba-chat-example/dashscope-chat | DashScope chat basics | `mvn -pl spring-ai-alibaba-chat-example/dashscope-chat spring-boot:run` | none | `AI_DASHSCOPE_API_KEY` | — | [README](./spring-ai-alibaba-chat-example/dashscope-chat/README.md) |
+| spring-ai-alibaba-image-example/dashscope-image | DashScope image generation | `mvn -pl spring-ai-alibaba-image-example/dashscope-image spring-boot:run` | none | `AI_DASHSCOPE_API_KEY` | — | [README](./spring-ai-alibaba-image-example/dashscope-image/README.md) |
+| spring-ai-alibaba-mcp-example | MCP demo | `mvn -pl spring-ai-alibaba-mcp-example spring-boot:run` | none/local mcp tool | model api key | [`.env.example`](./spring-ai-alibaba-mcp-example/.env.example) | [README](./spring-ai-alibaba-mcp-example/README.md) |
+| spring-ai-alibaba-rag-example | RAG demo | `mvn -pl spring-ai-alibaba-rag-example spring-boot:run` | vector db (optional by profile) | model api key, embedding model | [`.env.example`](./spring-ai-alibaba-rag-example/.env.example) | [README](./spring-ai-alibaba-rag-example/README.md) |
+| spring-ai-alibaba-tool-calling-example | tool calling | `mvn -pl spring-ai-alibaba-tool-calling-example spring-boot:run` | none | model api key, map api key | [`.env.example`](./spring-ai-alibaba-tool-calling-example/.env.example) | [README](./spring-ai-alibaba-tool-calling-example/README.md) |


### PR DESCRIPTION
## Summary
- add a small quickstart matrix to `README-en.md`

## Why
The Chinese README already includes a compact quickstart matrix, but the English README is still much more minimal. Adding a matching summary table improves parity for English-speaking readers.

## Scope
- add a `Quickstart Matrix` section to `README-en.md`
- include the same high-signal modules that are already highlighted in the root README flow
- keep the table compact and navigation-oriented

## Testing
- not run (documentation-only change)
