### PR TITLE
feat(tool-calling): enhance campus assistant tools

### DIFF
--- a/spring-ai-alibaba-tool-calling-example/README.md
+++ b/spring-ai-alibaba-tool-calling-example/README.md
@@ -4,7 +4,7 @@ Demonstrate four approaches to ToolCalling with four distinct examples here:
 - AddressController : Methods as Tools - MethodToolCallback
 - BaiduTranslateController : Function as Tools - Function Name 
 - WeatherController : Function as Tools - FunctionCallBack
-- CampusAssistantController : Combine time, weather, and campus schedule tools
+- CampusAssistantController : Combine time, weather, campus schedule, and activity risk tools
 
 If you want to build your own tools, you can refer to the implementation in the community module of the Spring AI Alibaba repository and use the currently stable version 1.0.0.2.
 
@@ -207,11 +207,17 @@ GET http://localhost:8080/weather/chat-tool-function-name
 - 默认上下文路径：/basic
 ## 测试指导
 ### 校园助手组合调用
-`CampusAssistantController` 演示了在同一个请求中组合三种工具：城市时间、天气查询和校园日程生成。
+`CampusAssistantController` 演示了在同一个请求中组合多种工具：城市时间、天气查询、校园日程生成和户外活动风险评估。
+其中 `CampusScheduleTools` 提供两个本地工具：
+- `createCampusSchedule`: 根据活动、开始时间和时长生成包含准备、主体活动和收尾阶段的校园计划。
+- `estimateCampusActivityRisk`: 根据天气摘要、活动和时长判断户外活动风险，并给出室内备选或缩短活动等建议。
 
 ```bash
-curl "http://localhost:8080/campus/chat-tools?query=请查询上海当前时间和天气，并为我安排一小时的校园跑步计划"
+curl "http://localhost:8080/campus/chat-tools?query=请查询上海当前时间和天气，评估户外活动风险，并为我安排一小时的校园跑步计划"
 ```
+
+更多可直接运行的请求示例可以查看模块根目录下的
+**[spring-ai-alibaba-tool-calling-example.http](./spring-ai-alibaba-tool-calling-example.http)**。
 
 ### 使用 HTTP 文件测试
 模块根目录下提供了 **[spring-ai-alibaba-tool-calling-example.http](./spring-ai-alibaba-tool-calling-example.http)** 文件，包含所有接口的测试用例：

--- a/spring-ai-alibaba-tool-calling-example/spring-ai-alibaba-tool-calling-example.http
+++ b/spring-ai-alibaba-tool-calling-example/spring-ai-alibaba-tool-calling-example.http
@@ -32,3 +32,11 @@ GET http://localhost:8080/weather/chat-tool-function-name?query=请告诉我北�
 ###
 # CampusAssistantController类的chatWithCampusTools方法
 GET http://localhost:8080/campus/chat-tools?query=请查询上海当前时间和天气，并为我安排一小时的校园跑步计划
+
+###
+# CampusAssistantController类的多工具风险评估示例
+GET http://localhost:8080/campus/chat-tools?query=请查询杭州今天下午的天气，判断是否适合进行两小时校园社团招新活动，并给出时间安排
+
+###
+# CampusAssistantController类的室内备选方案示例
+GET http://localhost:8080/campus/chat-tools?query=如果上海今晚下雨，请帮我安排一个室内自习和运动结合的校园计划

--- a/spring-ai-alibaba-tool-calling-example/src/main/java/com/alibaba/cloud/ai/toolcall/component/CampusScheduleTools.java
+++ b/spring-ai-alibaba-tool-calling-example/src/main/java/com/alibaba/cloud/ai/toolcall/component/CampusScheduleTools.java
@@ -34,9 +34,17 @@ public class CampusScheduleTools {
             throw new IllegalArgumentException("Duration must be greater than zero.");
         }
 
-        int preparationMinutes = Math.min(10, Math.max(5, durationMinutes / 6));
-        int wrapUpMinutes = Math.min(10, Math.max(5, durationMinutes / 8));
-        int mainActivityMinutes = Math.max(1, durationMinutes - preparationMinutes - wrapUpMinutes);
+        int desiredPreparationMinutes = Math.min(10, Math.max(5, durationMinutes / 6));
+        int desiredWrapUpMinutes = Math.min(10, Math.max(5, durationMinutes / 8));
+        int availableTransitionMinutes = durationMinutes - 1;
+        int preparationMinutes = desiredPreparationMinutes;
+        int wrapUpMinutes = desiredWrapUpMinutes;
+        if (desiredPreparationMinutes + desiredWrapUpMinutes > availableTransitionMinutes) {
+            preparationMinutes = availableTransitionMinutes * desiredPreparationMinutes
+                    / (desiredPreparationMinutes + desiredWrapUpMinutes);
+            wrapUpMinutes = availableTransitionMinutes - preparationMinutes;
+        }
+        int mainActivityMinutes = durationMinutes - preparationMinutes - wrapUpMinutes;
 
         return "Campus schedule plan: activity=" + activity + ", startTime=" + startTime
                 + ", durationMinutes=" + durationMinutes
@@ -71,8 +79,10 @@ public class CampusScheduleTools {
         }
 
         if (durationMinutes > 120 && !"HIGH".equals(riskLevel)) {
+            boolean hasWeatherRisk = !"LOW".equals(riskLevel);
             riskLevel = "MEDIUM";
-            suggestion = "Long activity duration detected. Add breaks and hydration reminders.";
+            String longActivitySuggestion = "Long activity duration detected. Add breaks and hydration reminders.";
+            suggestion = hasWeatherRisk ? suggestion + " " + longActivitySuggestion : longActivitySuggestion;
         }
 
         return "Campus activity risk: activity=" + activity + ", durationMinutes=" + durationMinutes

--- a/spring-ai-alibaba-tool-calling-example/src/main/java/com/alibaba/cloud/ai/toolcall/component/CampusScheduleTools.java
+++ b/spring-ai-alibaba-tool-calling-example/src/main/java/com/alibaba/cloud/ai/toolcall/component/CampusScheduleTools.java
@@ -15,23 +15,83 @@
  */
 package com.alibaba.cloud.ai.toolcall.component;
 
+import java.util.Locale;
+
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 
 public class CampusScheduleTools {
 
-    @Tool(description = "Create a concise campus activity schedule after considering the user's request.")
+    @Tool(description = "Create a campus activity schedule with preparation, main activity, and wrap-up steps.")
     public String createCampusSchedule(
             @ToolParam(description = "Campus activity or study goal.") String activity,
             @ToolParam(description = "Recommended start time, such as 14:00.") String startTime,
             @ToolParam(description = "Duration in minutes.") int durationMinutes) {
 
+        requireText(activity, "Activity");
+        requireText(startTime, "Start time");
         if (durationMinutes <= 0) {
             throw new IllegalArgumentException("Duration must be greater than zero.");
         }
 
-        return "Campus schedule: activity=" + activity + ", startTime=" + startTime
-                + ", durationMinutes=" + durationMinutes + ".";
+        int preparationMinutes = Math.min(10, Math.max(5, durationMinutes / 6));
+        int wrapUpMinutes = Math.min(10, Math.max(5, durationMinutes / 8));
+        int mainActivityMinutes = Math.max(1, durationMinutes - preparationMinutes - wrapUpMinutes);
+
+        return "Campus schedule plan: activity=" + activity + ", startTime=" + startTime
+                + ", durationMinutes=" + durationMinutes
+                + ". Suggested flow: preparation=" + preparationMinutes + " minutes, mainActivity="
+                + mainActivityMinutes + " minutes, wrapUp=" + wrapUpMinutes
+                + " minutes. Reminder: check weather and campus safety rules before outdoor activities.";
+    }
+
+    @Tool(description = "Estimate whether a campus outdoor activity should continue based on weather and duration.")
+    public String estimateCampusActivityRisk(
+            @ToolParam(description = "Weather summary returned by a weather tool.") String weatherSummary,
+            @ToolParam(description = "Campus activity or study goal.") String activity,
+            @ToolParam(description = "Duration in minutes.") int durationMinutes) {
+
+        requireText(weatherSummary, "Weather summary");
+        requireText(activity, "Activity");
+        if (durationMinutes <= 0) {
+            throw new IllegalArgumentException("Duration must be greater than zero.");
+        }
+
+        String normalizedWeather = weatherSummary.toLowerCase(Locale.ROOT);
+        String riskLevel = "LOW";
+        String suggestion = "Activity can continue as planned.";
+
+        if (containsAny(normalizedWeather, "storm", "thunder", "snow", "hail", "暴雨", "雷", "雪", "冰雹")) {
+            riskLevel = "HIGH";
+            suggestion = "Move the activity indoors or postpone it.";
+        }
+        else if (containsAny(normalizedWeather, "rain", "wind", "hot", "cold", "fog", "雨", "风", "高温", "低温", "雾")) {
+            riskLevel = "MEDIUM";
+            suggestion = "Shorten the activity, prepare protection, and choose a nearby indoor backup place.";
+        }
+
+        if (durationMinutes > 120 && !"HIGH".equals(riskLevel)) {
+            riskLevel = "MEDIUM";
+            suggestion = "Long activity duration detected. Add breaks and hydration reminders.";
+        }
+
+        return "Campus activity risk: activity=" + activity + ", durationMinutes=" + durationMinutes
+                + ", riskLevel=" + riskLevel + ", suggestion=" + suggestion;
+    }
+
+    private void requireText(String value, String fieldName) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank.");
+        }
+    }
+
+    private boolean containsAny(String text, String... keywords) {
+        for (String keyword : keywords) {
+            if (text.contains(keyword)) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/spring-ai-alibaba-tool-calling-example/src/main/java/com/alibaba/cloud/ai/toolcall/controller/CampusAssistantController.java
+++ b/spring-ai-alibaba-tool-calling-example/src/main/java/com/alibaba/cloud/ai/toolcall/controller/CampusAssistantController.java
@@ -51,7 +51,7 @@ public class CampusAssistantController {
      */
     @GetMapping("/chat-tools")
     public String chatWithCampusTools(@RequestParam(value = "query",
-            defaultValue = "请查询上海当前时间和天气，并为我安排一小时的校园跑步计划") String query) {
+            defaultValue = "请查询上海当前时间和天气，评估户外活动风险，并为我安排一小时的校园跑步计划") String query) {
 
         return dashScopeChatClient.prompt(query)
                 .tools(timeTools, campusScheduleTools)

--- a/spring-ai-alibaba-tool-calling-example/src/test/java/com/alibaba/cloud/ai/toolcall/component/CampusScheduleToolsTest.java
+++ b/spring-ai-alibaba-tool-calling-example/src/test/java/com/alibaba/cloud/ai/toolcall/component/CampusScheduleToolsTest.java
@@ -41,6 +41,18 @@ class CampusScheduleToolsTest {
     }
 
     @Test
+    void shouldKeepShortScheduleWithinRequestedDuration() {
+        String result = campusScheduleTools.createCampusSchedule("stretch", "14:00", 5);
+
+        assertAll(
+                () -> assertTrue(result.contains("durationMinutes=5")),
+                () -> assertTrue(result.contains("preparation=2 minutes")),
+                () -> assertTrue(result.contains("mainActivity=1 minutes")),
+                () -> assertTrue(result.contains("wrapUp=2 minutes"))
+        );
+    }
+
+    @Test
     void shouldRejectZeroDuration() {
         assertThrows(IllegalArgumentException.class,
                 () -> campusScheduleTools.createCampusSchedule("run", "14:00", 0));
@@ -91,6 +103,18 @@ class CampusScheduleToolsTest {
 
         assertAll(
                 () -> assertTrue(result.contains("riskLevel=MEDIUM")),
+                () -> assertTrue(result.contains("Long activity duration detected"))
+        );
+    }
+
+    @Test
+    void shouldPreserveWeatherAdviceForLongActivity() {
+        String result = campusScheduleTools.estimateCampusActivityRisk("light rain", "run", 180);
+
+        assertAll(
+                () -> assertTrue(result.contains("riskLevel=MEDIUM")),
+                () -> assertTrue(result.contains("prepare protection")),
+                () -> assertTrue(result.contains("indoor backup place")),
                 () -> assertTrue(result.contains("Long activity duration detected"))
         );
     }

--- a/spring-ai-alibaba-tool-calling-example/src/test/java/com/alibaba/cloud/ai/toolcall/component/CampusScheduleToolsTest.java
+++ b/spring-ai-alibaba-tool-calling-example/src/test/java/com/alibaba/cloud/ai/toolcall/component/CampusScheduleToolsTest.java
@@ -17,8 +17,10 @@ package com.alibaba.cloud.ai.toolcall.component;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CampusScheduleToolsTest {
 
@@ -26,8 +28,16 @@ class CampusScheduleToolsTest {
 
     @Test
     void shouldCreateCampusSchedule() {
-        assertEquals("Campus schedule: activity=run, startTime=14:00, durationMinutes=60.",
-                campusScheduleTools.createCampusSchedule("run", "14:00", 60));
+        String result = campusScheduleTools.createCampusSchedule("run", "14:00", 60);
+
+        assertAll(
+                () -> assertTrue(result.contains("activity=run")),
+                () -> assertTrue(result.contains("startTime=14:00")),
+                () -> assertTrue(result.contains("durationMinutes=60")),
+                () -> assertTrue(result.contains("preparation=10 minutes")),
+                () -> assertTrue(result.contains("mainActivity=43 minutes")),
+                () -> assertTrue(result.contains("wrapUp=7 minutes"))
+        );
     }
 
     @Test
@@ -40,6 +50,55 @@ class CampusScheduleToolsTest {
     void shouldRejectNegativeDuration() {
         assertThrows(IllegalArgumentException.class,
                 () -> campusScheduleTools.createCampusSchedule("run", "14:00", -1));
+    }
+
+    @Test
+    void shouldRejectBlankActivity() {
+        assertThrows(IllegalArgumentException.class,
+                () -> campusScheduleTools.createCampusSchedule(" ", "14:00", 60));
+    }
+
+    @Test
+    void shouldEstimateLowRiskForClearWeather() {
+        assertEquals("Campus activity risk: activity=run, durationMinutes=60, riskLevel=LOW, "
+                        + "suggestion=Activity can continue as planned.",
+                campusScheduleTools.estimateCampusActivityRisk("clear and mild", "run", 60));
+    }
+
+    @Test
+    void shouldEstimateMediumRiskForRain() {
+        String result = campusScheduleTools.estimateCampusActivityRisk("light rain", "run", 60);
+
+        assertAll(
+                () -> assertTrue(result.contains("riskLevel=MEDIUM")),
+                () -> assertTrue(result.contains("Shorten the activity"))
+        );
+    }
+
+    @Test
+    void shouldEstimateHighRiskForStorm() {
+        String result = campusScheduleTools.estimateCampusActivityRisk("thunder storm", "run", 60);
+
+        assertAll(
+                () -> assertTrue(result.contains("riskLevel=HIGH")),
+                () -> assertTrue(result.contains("Move the activity indoors"))
+        );
+    }
+
+    @Test
+    void shouldRaiseRiskForLongActivity() {
+        String result = campusScheduleTools.estimateCampusActivityRisk("clear", "club activity", 180);
+
+        assertAll(
+                () -> assertTrue(result.contains("riskLevel=MEDIUM")),
+                () -> assertTrue(result.contains("Long activity duration detected"))
+        );
+    }
+
+    @Test
+    void shouldRejectBlankWeatherSummary() {
+        assertThrows(IllegalArgumentException.class,
+                () -> campusScheduleTools.estimateCampusActivityRisk(" ", "run", 60));
     }
 
 }


### PR DESCRIPTION
## Summary

- Expand `CampusScheduleTools#createCampusSchedule` to return a staged campus plan with preparation, main activity, and wrap-up steps.
- Add `estimateCampusActivityRisk` as a second local tool for weather-aware outdoor activity decisions.
- Add validation for blank text input and invalid duration.
- Add more HTTP request scenarios and README guidance for the advanced campus assistant example.
- Increase unit tests from 3 to 9 cases.

## Why

The merged campus assistant example demonstrates basic multi-tool composition. This follow-up makes it a stronger tutorial by showing multiple local `@Tool` methods, tool parameter validation, weather-aware risk estimation, and local tests that do not require external API keys.

## Tests

```text
mvn -f spring-ai-alibaba-tool-calling-example/pom.xml test
```

```text
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## Related

- https://github.com/alibaba/spring-ai-alibaba/issues/4715
- Follow-up to https://github.com/spring-ai-alibaba/examples/pull/463